### PR TITLE
Use latest rapidjson as submodule and strip down unneeded build features.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /build*/
 /.vscode/
-/thirdparty/
 .vs/
 .DS_Store

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "thirdparty/rapidjson"]
+	path = thirdparty/rapidjson
+	url = https://github.com/Tencent/rapidjson

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,56 +1,5 @@
 cmake_minimum_required (VERSION 3.2.0)
 project (DiscordRPC)
 
-include(GNUInstallDirs)
-
-option(BUILD_EXAMPLES "Build example apps" ON)
-
-# format
-file(GLOB_RECURSE ALL_SOURCE_FILES
-    examples/*.cpp examples/*.h examples/*.c
-    include/*.h
-    src/*.cpp src/*.h src/*.c
-)
-
-# Set CLANG_FORMAT_SUFFIX if you are using custom clang-format, e.g. clang-format-5.0
-find_program(CLANG_FORMAT_CMD clang-format${CLANG_FORMAT_SUFFIX})
-
-if (CLANG_FORMAT_CMD)
-    add_custom_target(
-        clangformat
-        COMMAND ${CLANG_FORMAT_CMD}
-        -i -style=file -fallback-style=none
-        ${ALL_SOURCE_FILES}
-        DEPENDS
-        ${ALL_SOURCE_FILES}
-    )
-endif(CLANG_FORMAT_CMD)
-
-# thirdparty stuff
-execute_process(
-    COMMAND mkdir ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty
-    ERROR_QUIET
-)
-
-find_file(RAPIDJSONTEST NAMES rapidjson rapidjson-1.1.0 PATHS ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty CMAKE_FIND_ROOT_PATH_BOTH)
-if (NOT RAPIDJSONTEST)
-    message("no rapidjson, download")
-    set(RJ_TAR_FILE ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/v1.1.0.tar.gz)
-    file(DOWNLOAD https://github.com/miloyip/rapidjson/archive/v1.1.0.tar.gz ${RJ_TAR_FILE})
-    execute_process(
-        COMMAND ${CMAKE_COMMAND} -E tar xzf ${RJ_TAR_FILE}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty
-    )
-    file(REMOVE ${RJ_TAR_FILE})
-endif(NOT RAPIDJSONTEST)
-
-find_file(RAPIDJSON NAMES rapidjson rapidjson-1.1.0 PATHS ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty CMAKE_FIND_ROOT_PATH_BOTH)
-
-add_library(rapidjson STATIC IMPORTED ${RAPIDJSON})
-
-# add subdirs
-
+set(RAPIDJSON ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/rapidjson)
 add_subdirectory(src)
-if (BUILD_EXAMPLES)
-    add_subdirectory(examples/send-presence)
-endif(BUILD_EXAMPLES)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -110,6 +110,7 @@ if(UNIX)
 endif(UNIX)
 
 target_include_directories(discord-rpc PRIVATE ${RAPIDJSON}/include)
+target_include_directories(discord-rpc INTERFACE ${PROJECT_SOURCE_DIR}/include)
 
 if (NOT ${ENABLE_IO_THREAD})
     target_compile_definitions(discord-rpc PUBLIC -DDISCORD_DISABLE_IO_THREAD)
@@ -119,29 +120,3 @@ if (${BUILD_SHARED_LIBS})
     target_compile_definitions(discord-rpc PUBLIC -DDISCORD_DYNAMIC_LIB)
     target_compile_definitions(discord-rpc PRIVATE -DDISCORD_BUILDING_SDK)
 endif(${BUILD_SHARED_LIBS})
-
-if (CLANG_FORMAT_CMD)
-    add_dependencies(discord-rpc clangformat)
-endif(CLANG_FORMAT_CMD)
-
-# install
-
-install(
-    TARGETS discord-rpc
-    EXPORT "discord-rpc"
-    RUNTIME
-        DESTINATION "${CMAKE_INSTALL_BINDIR}"
-    LIBRARY
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    ARCHIVE
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    INCLUDES
-        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-)
-
-install(
-    FILES
-        "../include/discord_rpc.h"
-		"../include/discord_register.h"
-    DESTINATION "include"
-)


### PR DESCRIPTION
* Use latest rapidjson as submodule. This should fix GCC compilation and make sure the source is part of the repository, rather than downloading an external source tar at configure time.
* Remove a bunch of unnecessary build features for us like examples, installing, and clang format.